### PR TITLE
Fix property creation for admins

### DIFF
--- a/backend/controllers/propertyController.js
+++ b/backend/controllers/propertyController.js
@@ -50,7 +50,7 @@ const createProperty = async (req, res) => {
   } = req.body;
 
   try {
-    const property = new Property({
+    const property = await Property.create({
       title,
       description,
       price,
@@ -61,9 +61,7 @@ const createProperty = async (req, res) => {
       images,
       agent: req.user._id,
     });
-
-    const createdProperty = await property.save();
-    res.status(201).json(createdProperty);
+    res.status(201).json(property);
   } catch (error) {
     console.error(error);
     res.status(500).json({ message: "Server Error" });

--- a/backend/middleware/admin.js
+++ b/backend/middleware/admin.js
@@ -1,8 +1,17 @@
-const admin = (req, res, next) => {
-  if (req.user && req.user.role === "admin") {
-    next();
-  } else {
-    res.status(403).json({ message: "Not authorized as an admin" });
+import User from '../models/User.js';
+
+const admin = async (req, res, next) => {
+  try {
+    // Re-fetch user from DB to ensure role is up-to-date
+    const user = await User.findById(req.user.id);
+
+    if (user && user.role === 'admin') {
+      next();
+    } else {
+      res.status(403).json({ message: 'Not authorized as an admin' });
+    }
+  } catch (error) {
+    res.status(500).json({ message: 'Error verifying admin status' });
   }
 };
 


### PR DESCRIPTION
This commit addresses an issue where properties were not being saved to the database for admin users despite the API returning a success message.

The `createProperty` function in `propertyController.js` has been refactored to use the more concise `Property.create()` method.

More importantly, the `admin` middleware in `admin.js` has been made more robust. It now re-fetches the user from the database before checking their role. This ensures the authorization check is always based on the most current user data, preventing potential issues with stale roles in JWTs and making the admin protection more reliable.